### PR TITLE
chore: add team lead aggregate uniqueness test

### DIFF
--- a/models/silver/intermediate/int_team_lead_aggs.yml
+++ b/models/silver/intermediate/int_team_lead_aggs.yml
@@ -6,13 +6,11 @@ models:
       Team-level aggregated statistics analyzing lead behavior, comeback ability,
       and game control metrics across all games. One row per team per season type.
       Provides insights into team playing style, clutch performance, and efficiency.
-
     columns:
       - name: team
         description: Team abbreviation (e.g., 'LAL', 'BOS')
         data_tests:
           - not_null
-          - unique
 
       - name: team_full
         description: Full team name (e.g., 'Los Angeles Lakers')
@@ -336,6 +334,10 @@ models:
           - not_null
 
     data_tests:
+      - dbt_expectations.expect_compound_columns_to_be_unique:
+          arguments:
+            column_list: ["team", "season_type"]
+
       # Wins + losses should equal games played
       - dbt_utils.expression_is_true:
           arguments:


### PR DESCRIPTION
### Description
Adds a composite uniqueness test for team lead aggregates so each team and season type appears only once.

## Updated
- Replaced the single-column team uniqueness assertion with a composite team and season_type uniqueness test.