### PR TITLE
ci(dbt): add dbt port env var

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,6 +12,7 @@ env:
   IAM_ROLE: ${{ secrets.IAM_ROLE_ECR }}
   AWS_REGION: "us-east-1"
   DBT_HOST: ${{ secrets.DBT_HOST }}
+  DBT_PORT: ${{ secrets.DBT_PORT }}
   DBT_DBNAME: ${{ secrets.DBT_DBNAME }}
   DBT_SCHEMA: ${{ secrets.DBT_SCHEMA }}
   DBT_USER: ${{ secrets.DBT_USER }}


### PR DESCRIPTION
## Description

Adds the DBT_PORT secret to the CI/CD workflow so dbt uses the configured production database port instead of falling back to 5432.

## Updated
- Pass DBT_PORT through the workflow environment for dbt commands.