### PR TITLE
fix: use season rank in schedule table

### DIFF
--- a/models/silver/intermediate/int_schedule_table.sql
+++ b/models/silver/intermediate/int_schedule_table.sql
@@ -20,7 +20,7 @@ home_team_attributes as (
 home_team_rank as (
     select
         team_full as home_team,
-        row_number() over () as home_team_rank
+        season_rank as home_team_rank
     from {{ ref('int_standings_table') }}
 
 ),
@@ -51,7 +51,7 @@ away_team_odds as (
 away_team_rank as (
     select
         team_full as away_team,
-        row_number() over () as away_team_rank
+        season_rank as away_team_rank
     from {{ ref('int_standings_table') }}
 
 ),


### PR DESCRIPTION
### Description
Fix schedule-table team ranks by reusing the standings model season rank instead of generating arbitrary row numbers. This keeps home and away rank fields aligned with the source standings.

## Updated
- Use `season_rank` for home team rank
- Use `season_rank` for away team rank