### PR TITLE
feat(dbt): add playoff series metrics

### DIFF
--- a/models/gold/recent_games_teams.sql
+++ b/models/gold/recent_games_teams.sql
@@ -29,7 +29,7 @@ team_pts_scored as (
     select
         team,
         opponent,
-        game_date,
+        int_recent_games_teams.game_date,
         outcome,
         pts_scored,
         pts_scored_opp,
@@ -43,6 +43,9 @@ team_pts_scored as (
         team_logo,
         opp_logo,
         home_team,
+        series_games.round_name as series_round,
+        series_games.series_status_after_game as series_status,
+        series_games.series_game_number,
         case
             when team = home_team then 'Vs.'
             else '@'
@@ -50,6 +53,10 @@ team_pts_scored as (
     from {{ ref('int_recent_games_teams') }}
         inner join {{ ref('most_recent_game') }} on int_recent_games_teams.game_date = most_recent_game.max_game_date
         left join leads using (team, opponent)
+        left join {{ ref('int_playoff_series_games') }} as series_games
+            on int_recent_games_teams.game_date = series_games.game_date
+            and least(int_recent_games_teams.team, int_recent_games_teams.opponent) = series_games.team_a
+            and greatest(int_recent_games_teams.team, int_recent_games_teams.opponent) = series_games.team_b
     where outcome = 'W'
 )
 

--- a/models/gold/recent_games_teams.yml
+++ b/models/gold/recent_games_teams.yml
@@ -8,6 +8,16 @@ models:
           arguments:
             min_value: 0
             max_value: 15
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              (series_round is null and series_status is null and series_game_number is null)
+              or (
+                series_round in ('First Round', 'Conf. Semifinals', 'Conf. Finals', 'NBA Finals')
+                and series_status is not null
+                and series_game_number between 1 and 7
+              )
+          name: recent_games_teams_series_fields_are_consistent
     columns:
       - name: pts_color
         data_tests:
@@ -39,5 +49,11 @@ models:
               arguments:
                 min_value: 0
                 max_value: 60
+      - name: series_round
+        description: Playoff round label for the game, null outside the playoffs.
+      - name: series_status
+        description: Playoff series state after the game, null outside the playoffs.
+      - name: series_game_number
+        description: Game number within the playoff series, null outside the playoffs.
       - name: __created_at
         description: Timestamp when this gold model was produced by dbt.

--- a/models/gold/schedule.sql
+++ b/models/gold/schedule.sql
@@ -2,24 +2,31 @@
 
 with new_odds as (
     select
-        game_date,
-        day_name,
-        game_ts,
-        avg_team_rank,
-        home_team,
-        away_team,
-        home_moneyline as home_moneyline_raw,
-        away_moneyline as away_moneyline_raw,
-        concat(start_time, ' PM') as start_time,
+        schedule_table.game_date,
+        schedule_table.day_name,
+        schedule_table.game_ts,
+        schedule_table.avg_team_rank,
+        schedule_table.home_team,
+        schedule_table.away_team,
+        schedule_table.home_moneyline as home_moneyline_raw,
+        schedule_table.away_moneyline as away_moneyline_raw,
+        concat(schedule_table.start_time, ' PM') as start_time,
+        series_games.round_name as series_round,
+        series_games.series_status_before_game as series_status,
+        series_games.series_game_number,
         case
-            when home_moneyline::numeric > 0 then concat('+', home_moneyline::text)
-            else home_moneyline::text
+            when schedule_table.home_moneyline::numeric > 0 then concat('+', schedule_table.home_moneyline::text)
+            else schedule_table.home_moneyline::text
         end as home_moneyline,
         case
-            when away_moneyline::numeric > 0 then concat('+', away_moneyline::text)
-            else away_moneyline::text
+            when schedule_table.away_moneyline::numeric > 0 then concat('+', schedule_table.away_moneyline::text)
+            else schedule_table.away_moneyline::text
         end as away_moneyline
-    from {{ ref('int_schedule_table') }}
+    from {{ ref('int_schedule_table') }} as schedule_table
+        left join {{ ref('int_playoff_series_games') }} as series_games
+            on schedule_table.game_date = series_games.game_date
+            and least(schedule_table.home_team_acronym, schedule_table.away_team_acronym) = series_games.team_a
+            and greatest(schedule_table.home_team_acronym, schedule_table.away_team_acronym) = series_games.team_b
 ),
 
 
@@ -52,6 +59,9 @@ aws_schedule_table as (
         away_moneyline_raw,
         home_team_logo,
         away_team_logo,
+        series_round,
+        series_status,
+        series_game_number,
         case
             when home_moneyline is null then home_team
             else concat(home_team, ' (', home_moneyline, ')')

--- a/models/gold/schedule.yml
+++ b/models/gold/schedule.yml
@@ -7,6 +7,16 @@ models:
       - dbt_expectations.expect_compound_columns_to_be_unique:
           arguments:
             column_list: ["game_date", "home_team"]
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              (series_round is null and series_status is null and series_game_number is null)
+              or (
+                series_round in ('First Round', 'Conf. Semifinals', 'Conf. Finals', 'NBA Finals')
+                and series_status is not null
+                and series_game_number between 1 and 7
+              )
+          name: schedule_series_fields_are_consistent
     columns:
       - name: avg_team_rank
         data_tests:
@@ -14,3 +24,9 @@ models:
               arguments:
                 min_value: 1
                 max_value: 30
+      - name: series_round
+        description: Playoff round label for the scheduled game, null outside the playoffs.
+      - name: series_status
+        description: Playoff series state entering the scheduled game, null outside the playoffs.
+      - name: series_game_number
+        description: Game number within the playoff series, null outside the playoffs.

--- a/models/gold/schedule_season_remaining.sql
+++ b/models/gold/schedule_season_remaining.sql
@@ -1,7 +1,21 @@
 {{ config(materialized='view') }}
 
 select
-    *,
+    game_date,
+    day_name,
+    game_ts,
+    avg_team_rank,
+    start_time,
+    home_team,
+    away_team,
+    home_moneyline_raw,
+    away_moneyline_raw,
+    home_team_logo,
+    away_team_logo,
+    series_round,
+    series_game_number,
+    home_team_odds,
+    away_team_odds,
     {{ dbt.current_timestamp() }} as __created_at
 from {{ ref('schedule') }}
 where game_date > current_date

--- a/models/gold/schedule_season_remaining.yml
+++ b/models/gold/schedule_season_remaining.yml
@@ -4,5 +4,19 @@ models:
   - name: schedule_season_remaining
     description: Schedule Season Remaining dashboard table.
     columns:
+      - name: series_round
+        description: Playoff round label for the future game, null outside the playoffs.
+      - name: series_game_number
+        description: Game number within the playoff series, null outside the playoffs.
       - name: __created_at
         description: Timestamp when this gold model was produced by dbt.
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              (series_round is null and series_game_number is null)
+              or (
+                series_round in ('First Round', 'Conf. Semifinals', 'Conf. Finals', 'NBA Finals')
+                and series_game_number between 1 and 7
+              )
+          name: schedule_season_remaining_series_fields_are_consistent

--- a/models/gold/schedule_tonights_games.sql
+++ b/models/gold/schedule_tonights_games.sql
@@ -17,6 +17,9 @@ select
     away_moneyline,
     home_team_predicted_win_pct,
     away_team_predicted_win_pct,
+    series_round,
+    series_status,
+    series_game_number,
     -- booleans used in the dashboard cells to highlight teams w/ good bet value
     {{ is_great_bet_value('home_moneyline', 'home_team_predicted_win_pct') }} as home_is_great_value,
     {{ is_great_bet_value('away_moneyline', 'away_team_predicted_win_pct') }} as away_is_great_value

--- a/models/gold/schedule_tonights_games.yml
+++ b/models/gold/schedule_tonights_games.yml
@@ -4,5 +4,22 @@ models:
   - name: schedule_tonights_games
     description: Schedule Tonights Games dashboard table.
     columns:
+      - name: series_round
+        description: Playoff round label for tonight's game, null outside the playoffs.
+      - name: series_status
+        description: Playoff series state entering tonight's game, null outside the playoffs.
+      - name: series_game_number
+        description: Game number within the playoff series, null outside the playoffs.
       - name: __created_at
         description: Timestamp when this gold model was produced by dbt.
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              (series_round is null and series_status is null and series_game_number is null)
+              or (
+                series_round in ('First Round', 'Conf. Semifinals', 'Conf. Finals', 'NBA Finals')
+                and series_status is not null
+                and series_game_number between 1 and 7
+              )
+          name: schedule_tonights_games_series_fields_are_consistent

--- a/models/silver/intermediate/int_playoff_series.sql
+++ b/models/silver/intermediate/int_playoff_series.sql
@@ -1,0 +1,57 @@
+with series_totals as (
+    select
+        series_id,
+        season,
+        round_number,
+        round_name,
+        team_a,
+        team_b,
+        count(*) as scheduled_games_count,
+        sum(case when is_played then 1 else 0 end) as games_played,
+        max(team_a_wins_after_game) as team_a_wins,
+        max(team_b_wins_after_game) as team_b_wins
+    from {{ ref('int_playoff_series_games') }}
+    group by
+        series_id,
+        season,
+        round_number,
+        round_name,
+        team_a,
+        team_b
+),
+
+series_state as (
+    select
+        *,
+        case
+            when team_a_wins > team_b_wins then team_a
+            when team_b_wins > team_a_wins then team_b
+        end as series_leader,
+        greatest(team_a_wins, team_b_wins) as leader_wins,
+        least(team_a_wins, team_b_wins) as trailer_wins,
+        greatest(team_a_wins, team_b_wins) >= 4 as is_series_over
+    from series_totals
+)
+
+select
+    series_id,
+    season,
+    round_number,
+    round_name,
+    team_a,
+    team_b,
+    team_a_wins,
+    team_b_wins,
+    games_played,
+    scheduled_games_count,
+    series_leader,
+    leader_wins,
+    trailer_wins,
+    case
+        when games_played = 0 then 'Game 1'
+        when series_leader is null then concat('Series tied ', leader_wins::text, '-', trailer_wins::text)
+        when is_series_over then concat(series_leader, ' wins ', leader_wins::text, '-', trailer_wins::text)
+        else concat(series_leader, ' leads ', leader_wins::text, '-', trailer_wins::text)
+    end as series_status,
+    is_series_over
+from series_state

--- a/models/silver/intermediate/int_playoff_series.yml
+++ b/models/silver/intermediate/int_playoff_series.yml
@@ -1,0 +1,144 @@
+version: 2
+
+models:
+  - name: int_playoff_series
+    description: One row per playoff series with current aggregate series state.
+    columns:
+      - name: series_id
+        description: Stable playoff series identifier built from season, round, and matchup teams.
+        data_tests:
+          - unique
+          - not_null
+      - name: season
+        description: Playoff year.
+        data_tests:
+          - not_null
+      - name: round_number
+        description: Numeric playoff round, where 1 is first round and 4 is NBA Finals.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 1
+                max_value: 4
+      - name: round_name
+        description: Display name for the playoff round.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              arguments:
+                value_set:
+                  [
+                    "First Round",
+                    "Conf. Semifinals",
+                    "Conf. Finals",
+                    "NBA Finals",
+                  ]
+      - name: team_a
+        description: Alphabetically first team abbreviation in the matchup.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_acronym
+      - name: team_b
+        description: Alphabetically second team abbreviation in the matchup.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_acronym
+      - name: team_a_wins
+        description: Current series wins for team_a.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: team_b_wins
+        description: Current series wins for team_b.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: games_played
+        description: Number of completed games in the series.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 7
+      - name: scheduled_games_count
+        description: Number of scheduled games available for the series.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 1
+                max_value: 7
+      - name: series_leader
+        description: Team abbreviation for the current series leader, null when tied.
+      - name: leader_wins
+        description: Current wins for the leading team, or either side's wins when tied.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: trailer_wins
+        description: Current wins for the trailing team, or either side's wins when tied.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: series_status
+        description: Preformatted current display text, such as NYK leads 2-0.
+        data_tests:
+          - not_null
+      - name: is_series_over
+        description: True once a team reaches four wins.
+        data_tests:
+          - not_null
+
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "team_a < team_b"
+          name: int_playoff_series_team_order_is_stable
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "games_played = team_a_wins + team_b_wins"
+          name: int_playoff_series_games_played_matches_wins
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "leader_wins = greatest(team_a_wins, team_b_wins)"
+          name: int_playoff_series_leader_wins_matches_raw_wins
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "trailer_wins = least(team_a_wins, team_b_wins)"
+          name: int_playoff_series_trailer_wins_matches_raw_wins
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "leader_wins >= trailer_wins"
+          name: int_playoff_series_leader_wins_not_below_trailer_wins
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "(series_leader is null and team_a_wins = team_b_wins) or (series_leader in (team_a, team_b) and team_a_wins != team_b_wins)"
+          name: int_playoff_series_leader_matches_win_state
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_series_over = (leader_wins >= 4)"
+          name: int_playoff_series_over_flag_matches_wins
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "(games_played > 0) or (series_status = 'Game 1')"
+          name: int_playoff_series_unplayed_series_status_is_game_1

--- a/models/silver/intermediate/int_playoff_series_games.sql
+++ b/models/silver/intermediate/int_playoff_series_games.sql
@@ -1,0 +1,184 @@
+with playoff_schedule_games as (
+    select
+        extract(year from game_date)::int as season,
+        game_date,
+        game_ts,
+        home_team_acronym,
+        away_team_acronym,
+        least(home_team_acronym, away_team_acronym) as team_a,
+        greatest(home_team_acronym, away_team_acronym) as team_b
+    from {{ ref('int_schedule_table') }}
+    where season_type = 'Playoffs'
+),
+
+game_results as (
+    select
+        extract(year from game_date)::int as season,
+        game_date,
+        max(case when location = 'H' then team when location = 'A' then opponent end) as home_team_acronym,
+        max(case when location = 'A' then team when location = 'H' then opponent end) as away_team_acronym,
+        least(team, opponent) as team_a,
+        greatest(team, opponent) as team_b,
+        max(case when outcome = 'W' then team end) as winning_team
+    from {{ ref('fact_boxscores') }}
+    where season_type = 'Playoffs'
+    group by
+        extract(year from game_date)::int,
+        game_date,
+        least(team, opponent),
+        greatest(team, opponent)
+),
+
+playoff_games as (
+    select
+        coalesce(schedule_games.season, results.season) as season,
+        coalesce(schedule_games.game_date, results.game_date) as game_date,
+        coalesce(schedule_games.game_ts, results.game_date::timestamp) as game_ts,
+        coalesce(schedule_games.home_team_acronym, results.home_team_acronym) as home_team_acronym,
+        coalesce(schedule_games.away_team_acronym, results.away_team_acronym) as away_team_acronym,
+        coalesce(schedule_games.team_a, results.team_a) as team_a,
+        coalesce(schedule_games.team_b, results.team_b) as team_b,
+        results.winning_team
+    from playoff_schedule_games as schedule_games
+        full outer join game_results as results
+            on schedule_games.season = results.season
+            and schedule_games.game_date = results.game_date
+            and schedule_games.team_a = results.team_a
+            and schedule_games.team_b = results.team_b
+),
+
+series_start_dates as (
+    select
+        season,
+        team_a,
+        team_b,
+        min(game_date) as series_start_date
+    from playoff_games
+    group by
+        season,
+        team_a,
+        team_b
+),
+
+series_order as (
+    select
+        *,
+        row_number() over (
+            partition by season
+            order by series_start_date, team_a, team_b
+        ) as series_order
+    from series_start_dates
+),
+
+series_rounds as (
+    select
+        *,
+        case
+            when series_order <= 8 then 1
+            when series_order <= 12 then 2
+            when series_order <= 14 then 3
+            else 4
+        end as round_number,
+        case
+            when series_order <= 8 then 'First Round'
+            when series_order <= 12 then 'Conf. Semifinals'
+            when series_order <= 14 then 'Conf. Finals'
+            else 'NBA Finals'
+        end as round_name
+    from series_order
+),
+
+numbered_games as (
+    select
+        concat(
+            games.season::text,
+            '-',
+            rounds.round_number::text,
+            '-',
+            games.team_a,
+            '-',
+            games.team_b
+        ) as series_id,
+        games.season,
+        rounds.round_number,
+        rounds.round_name,
+        games.team_a,
+        games.team_b,
+        games.home_team_acronym,
+        games.away_team_acronym,
+        games.game_date,
+        games.game_ts,
+        games.winning_team,
+        games.winning_team is not null as is_played,
+        row_number() over (
+            partition by games.season, rounds.round_number, games.team_a, games.team_b
+            order by games.game_date, games.game_ts
+        ) as series_game_number
+    from playoff_games as games
+        inner join series_rounds as rounds
+            on games.season = rounds.season
+            and games.team_a = rounds.team_a
+            and games.team_b = rounds.team_b
+),
+
+series_progress as (
+    select
+        *,
+        coalesce(sum(case when winning_team = team_a then 1 else 0 end) over (
+            partition by series_id
+            order by game_date, game_ts
+            rows between unbounded preceding and 1 preceding
+        ), 0) as team_a_wins_before_game,
+        coalesce(sum(case when winning_team = team_b then 1 else 0 end) over (
+            partition by series_id
+            order by game_date, game_ts
+            rows between unbounded preceding and 1 preceding
+        ), 0) as team_b_wins_before_game,
+        sum(case when winning_team = team_a then 1 else 0 end) over (
+            partition by series_id
+            order by game_date, game_ts
+            rows between unbounded preceding and current row
+        ) as team_a_wins_after_game,
+        sum(case when winning_team = team_b then 1 else 0 end) over (
+            partition by series_id
+            order by game_date, game_ts
+            rows between unbounded preceding and current row
+        ) as team_b_wins_after_game
+    from numbered_games
+),
+
+series_state as (
+    select
+        *,
+        case
+            when team_a_wins_before_game > team_b_wins_before_game then team_a
+            when team_b_wins_before_game > team_a_wins_before_game then team_b
+        end as series_leader_before_game,
+        greatest(team_a_wins_before_game, team_b_wins_before_game) as leader_wins_before_game,
+        least(team_a_wins_before_game, team_b_wins_before_game) as trailer_wins_before_game,
+        greatest(team_a_wins_before_game, team_b_wins_before_game) >= 4 as is_series_over_before_game,
+        case
+            when team_a_wins_after_game > team_b_wins_after_game then team_a
+            when team_b_wins_after_game > team_a_wins_after_game then team_b
+        end as series_leader_after_game,
+        greatest(team_a_wins_after_game, team_b_wins_after_game) as leader_wins_after_game,
+        least(team_a_wins_after_game, team_b_wins_after_game) as trailer_wins_after_game,
+        greatest(team_a_wins_after_game, team_b_wins_after_game) >= 4 as is_series_over_after_game
+    from series_progress
+)
+
+select
+    *,
+    case
+        when leader_wins_before_game = 0 and trailer_wins_before_game = 0 then 'Game 1'
+        when series_leader_before_game is null then concat('Series tied ', leader_wins_before_game::text, '-', trailer_wins_before_game::text)
+        when is_series_over_before_game then concat(series_leader_before_game, ' wins ', leader_wins_before_game::text, '-', trailer_wins_before_game::text)
+        else concat(series_leader_before_game, ' leads ', leader_wins_before_game::text, '-', trailer_wins_before_game::text)
+    end as series_status_before_game,
+    case
+        when leader_wins_after_game = 0 and trailer_wins_after_game = 0 then 'Game 1'
+        when series_leader_after_game is null then concat('Series tied ', leader_wins_after_game::text, '-', trailer_wins_after_game::text)
+        when is_series_over_after_game then concat(series_leader_after_game, ' wins ', leader_wins_after_game::text, '-', trailer_wins_after_game::text)
+        else concat(series_leader_after_game, ' leads ', leader_wins_after_game::text, '-', trailer_wins_after_game::text)
+    end as series_status_after_game
+from series_state

--- a/models/silver/intermediate/int_playoff_series_games.yml
+++ b/models/silver/intermediate/int_playoff_series_games.yml
@@ -1,0 +1,212 @@
+version: 2
+
+models:
+  - name: int_playoff_series_games
+    description: One row per scheduled or completed playoff game with before-game and after-game series state.
+    data_tests:
+      - dbt_expectations.expect_compound_columns_to_be_unique:
+          arguments:
+            column_list: [series_id, series_game_number]
+      - dbt_expectations.expect_compound_columns_to_be_unique:
+          arguments:
+            column_list: [game_date, team_a, team_b]
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "team_a < team_b"
+          name: int_playoff_series_games_team_order_is_stable
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "winning_team is null or winning_team in (team_a, team_b)"
+          name: int_playoff_series_games_winner_is_in_matchup
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_played = (winning_team is not null)"
+          name: int_playoff_series_games_is_played_matches_winner
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "team_a_wins_after_game - team_a_wins_before_game in (0, 1)"
+          name: int_playoff_series_games_team_a_win_delta_is_valid
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "team_b_wins_after_game - team_b_wins_before_game in (0, 1)"
+          name: int_playoff_series_games_team_b_win_delta_is_valid
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "(team_a_wins_after_game + team_b_wins_after_game) = (team_a_wins_before_game + team_b_wins_before_game + case when is_played then 1 else 0 end)"
+          name: int_playoff_series_games_after_wins_advance_by_result
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "(series_game_number != 1) or (team_a_wins_before_game = 0 and team_b_wins_before_game = 0 and series_status_before_game = 'Game 1')"
+          name: int_playoff_series_games_game_1_starts_at_zero_zero
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "(not is_played) or ((team_a_wins_after_game + team_b_wins_after_game) = series_game_number)"
+          name: int_playoff_series_games_played_game_number_matches_after_wins
+    columns:
+      - name: series_id
+        description: Stable playoff series identifier built from season, round, and matchup teams.
+        data_tests:
+          - not_null
+      - name: season
+        description: Playoff year.
+        data_tests:
+          - not_null
+      - name: round_number
+        description: Numeric playoff round, where 1 is first round and 4 is NBA Finals.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 1
+                max_value: 4
+      - name: round_name
+        description: Display name for the playoff round.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              arguments:
+                value_set:
+                  [
+                    "First Round",
+                    "Conf. Semifinals",
+                    "Conf. Finals",
+                    "NBA Finals",
+                  ]
+      - name: team_a
+        description: Alphabetically first team abbreviation in the matchup.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_acronym
+      - name: team_b
+        description: Alphabetically second team abbreviation in the matchup.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_acronym
+      - name: home_team_acronym
+        description: Home team abbreviation for this scheduled playoff game.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_acronym
+      - name: away_team_acronym
+        description: Away team abbreviation for this scheduled playoff game.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_acronym
+      - name: game_date
+        description: Game date from schedule or completed boxscores.
+        data_tests:
+          - not_null
+      - name: game_ts
+        description: Scheduled game timestamp, defaulted to midnight for completed games missing from the schedule.
+        data_tests:
+          - not_null
+      - name: winning_team
+        description: Winning team abbreviation when the game has been played.
+      - name: is_played
+        description: True when a winner exists for this playoff game.
+        data_tests:
+          - not_null
+      - name: series_game_number
+        description: Game number within the playoff series.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 1
+                max_value: 7
+      - name: team_a_wins_before_game
+        description: team_a series wins entering this game.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: team_b_wins_before_game
+        description: team_b series wins entering this game.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: team_a_wins_after_game
+        description: team_a series wins after this game.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: team_b_wins_after_game
+        description: team_b series wins after this game.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: series_leader_before_game
+        description: Team abbreviation leading the series entering this game, null when tied.
+      - name: leader_wins_before_game
+        description: Leading win count entering this game, or either side's wins when tied.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: trailer_wins_before_game
+        description: Trailing win count entering this game, or either side's wins when tied.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: is_series_over_before_game
+        description: True when the series was already over entering this scheduled game.
+        data_tests:
+          - not_null
+      - name: series_leader_after_game
+        description: Team abbreviation leading the series after this game, null when tied.
+      - name: leader_wins_after_game
+        description: Leading win count after this game, or either side's wins when tied.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: trailer_wins_after_game
+        description: Trailing win count after this game, or either side's wins when tied.
+        data_tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+                max_value: 4
+      - name: is_series_over_after_game
+        description: True when the series is over after this game.
+        data_tests:
+          - not_null
+      - name: series_status_before_game
+        description: Series display text entering this game.
+        data_tests:
+          - not_null
+      - name: series_status_after_game
+        description: Series display text after this game, when the game has been played.
+        data_tests:
+          - not_null

--- a/tests/test_playoff_boxscore_games_in_series_games.sql
+++ b/tests/test_playoff_boxscore_games_in_series_games.sql
@@ -1,0 +1,27 @@
+with playoff_boxscore_games as (
+    select distinct
+        extract(year from game_date)::int as season,
+        game_date,
+        least(team, opponent) as team_a,
+        greatest(team, opponent) as team_b
+    from {{ ref('fact_boxscores') }}
+    where season_type = 'Playoffs'
+),
+
+series_games as (
+    select
+        season,
+        game_date,
+        team_a,
+        team_b
+    from {{ ref('int_playoff_series_games') }}
+)
+
+select playoff_boxscore_games.*
+from playoff_boxscore_games
+    left join series_games
+        on playoff_boxscore_games.season = series_games.season
+        and playoff_boxscore_games.game_date = series_games.game_date
+        and playoff_boxscore_games.team_a = series_games.team_a
+        and playoff_boxscore_games.team_b = series_games.team_b
+where series_games.game_date is null


### PR DESCRIPTION
### Description
Adds playoff series context to the dbt marts used by dashboard game cards and schedule views. Series state is built from playoff schedule data plus completed boxscores so missing schedule rows do not drop played games.

## Added
- New playoff series intermediate models with current and per-game before/after status.
- Tests for series grain, win math, and completed boxscore games.

## Updated
- Gold schedule and recent-game marts to carry playoff round, status, and game number.